### PR TITLE
feat: Allow providing manual branch name

### DIFF
--- a/src/appimagetool/appimagetool.go
+++ b/src/appimagetool/appimagetool.go
@@ -555,7 +555,9 @@ func GenerateAppImage(appdir string) {
 		} else {
 			parts := strings.Split(os.Getenv("GITHUB_REPOSITORY"), "/")
 			var channel string
-			if os.Getenv("GITHUB_REF") != "" && os.Getenv("GITHUB_REF") != "refs/heads/master" {
+			if os.Getenv("APPIMAGETOOL_GH_BRANCH_DEPLOY") != "" {
+				channel = os.Getenv("APPIMAGETOOL_GH_BRANCH_DEPLOY")
+			} else if os.Getenv("GITHUB_REF") != "" && os.Getenv("GITHUB_REF") != "refs/heads/master" {
 				channel = "latest"
 			} else {
 				channel = "continuous"


### PR DESCRIPTION
Currently, go-appimage does not allow to provide the branch / tag name / channel from where
github releases can be updated (updateinformation). This is useful for releasing apps to, `beta`, `nightly` channels, by setting APPIMAGETOOL_GH_BRANCH_DEPLOY environment variable to the required branch/channel name.